### PR TITLE
Fixed generic template markdown headers

### DIFF
--- a/.github/ISSUE_TEMPLATE/generic-template.md
+++ b/.github/ISSUE_TEMPLATE/generic-template.md
@@ -7,22 +7,22 @@ assignees: ''
 
 ---
 
-##Summary:
+## Summary:
 _Fill in the problem with the solution/creation/situation of the ticket._
 
-##Unresolved questions:
+## Unresolved questions:
 _Any related questions that don’t have full answers to them._
 
-##Drawbacks:
+## Drawbacks:
 _Any potential negative results this problem with solution/creation/situation could have._
 
-##Possible Solutions:
+## Possible Solutions:
 _If there’s any trailing ideas and/or file URL path the assignee should look at._
 
-##Future Possibilities:
+## Future Possibilities:
 _Positive or negative results of this problem with solution/creation/situation could have._
 _Could be anything from code changes or test changes to use cases._
 
-##References:
+## References:
 _Add any wire frame link, images, videos, and/or confluence document that can help give more context._
 _Could also link any related tickets._


### PR DESCRIPTION
## Changes:

The headers in the general template weren't rendering as headers due to a lack of a space and added in the spaces to get them to render as headers

## Impacts and Notes:
Nothing functional

## Checklist:
- [x] updated the docs
